### PR TITLE
CI: Checkout submodules (`DLSS`) in every job that needs to build the crate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: CI
 on: [push, pull_request]
 
 env:
-  minrust: 1.65.0
+  minrust: 1.70.0
 
 jobs:
   test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,8 @@ jobs:
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4
+        with:
+          submodules: true
 
       - name: Install toolchain
         id: tc
@@ -89,6 +91,8 @@ jobs:
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4
+        with:
+          submodules: true
 
       - name: Install toolchain
         id: tc
@@ -119,6 +123,8 @@ jobs:
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4
+        with:
+          submodules: true
 
       - name: Install toolchain (${{ env.minrust }})
         id: tc
@@ -150,6 +156,8 @@ jobs:
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4
+        with:
+          submodules: true
 
       - name: Install toolchain
         id: tc

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -5,7 +5,7 @@ on:
     - cron: '0 2 * * *'
 
 env:
-  minrust: 1.65.0
+  minrust: 1.70.0
 
 jobs:
   test:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -35,6 +35,8 @@ jobs:
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4
+        with:
+          submodules: true
 
       - name: Install toolchain
         id: tc
@@ -91,6 +93,8 @@ jobs:
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4
+        with:
+          submodules: true
 
       - name: Install toolchain
         id: tc
@@ -117,6 +121,8 @@ jobs:
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4
+        with:
+          submodules: true
 
       - name: Install toolchain (${{ env.minrust }})
         id: tc
@@ -144,6 +150,8 @@ jobs:
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4
+        with:
+          submodules: true
 
       - name: Install toolchain
         id: tc

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -244,19 +244,8 @@ dependencies = [
  "ash",
  "derive_builder",
  "log",
- "nvngx-sys 0.3.0",
+ "nvngx-sys",
  "uuid",
- "widestring",
-]
-
-[[package]]
-name = "nvngx-sys"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96bc9b11de45736fe7dacf652b91e881f7d058bed87c13a62d167d93f0216679"
-dependencies = [
- "bindgen",
- "libc",
  "widestring",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22,9 +22,9 @@ dependencies = [
 
 [[package]]
 name = "bindgen"
-version = "0.71.1"
+version = "0.72.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f58bf3d7db68cfbac37cfc485a8d711e87e064c3d0fe0435b92f7a407f9d6b3"
+checksum = "4f72209734318d0b619a5e0f5129918b848c416e122a3c4ce054e03cb87b726f"
 dependencies = [
  "bitflags",
  "cexpr",

--- a/README.md
+++ b/README.md
@@ -16,10 +16,10 @@ The DLSS version used by this crate: [`3.10.1.0`](https://github.com/NVIDIA/DLSS
 
 ## Supported graphics APIs
 
-- Vulkan (only the [`ash`](https://crates.io/crates/ash) backend).
+- Vulkan (via [`ash`](https://crates.io/crates/ash) bindings).
 
 ## MSRV
-1.65
+1.70
 
 ## DLSS integration example
 

--- a/crates/nvngx-sys/Cargo.toml
+++ b/crates/nvngx-sys/Cargo.toml
@@ -19,7 +19,7 @@ include = [
 ]
 
 [build-dependencies]
-bindgen = "0.71"
+bindgen = "0.72"
 
 [dependencies]
 widestring = "1"

--- a/crates/nvngx-sys/Cargo.toml
+++ b/crates/nvngx-sys/Cargo.toml
@@ -7,7 +7,7 @@ description = "NVIDIA NGX raw bindings."
 readme = "README.md"
 license = "MIT"
 keywords = ["nvidia", "ngx", "DLSS", "upscaling", "supersampling"]
-rust-version = "1.57"
+rust-version = "1.70"
 repository = "https://github.com/iddm/nvngx-rs"
 documentation = "https://docs.rs/nvngx-rs"
 

--- a/crates/nvngx-sys/build.rs
+++ b/crates/nvngx-sys/build.rs
@@ -98,10 +98,13 @@ fn main() {
     // Tell cargo to invalidate the built crate whenever the wrapper changes
     println!("cargo:rerun-if-changed={HEADER_FILE_PATH}");
 
+    let msrv = bindgen::RustTarget::stable(70, 0).unwrap();
+
     // The bindgen::Builder is the main entry point
     // to bindgen, and lets you build up options for
     // the resulting bindings.
     let bindings = bindgen::Builder::default()
+        .rust_target(msrv)
         // The input header we would like to generate
         // bindings for.
         .header(HEADER_FILE_PATH)

--- a/crates/nvngx/Cargo.toml
+++ b/crates/nvngx/Cargo.toml
@@ -17,5 +17,4 @@ ash = "0.37"
 log = "0.4"
 uuid = { version = "1", features = ["v4"] }
 derive_builder = "0.12"
-nvngx-sys = "0.3.0"
-# nvngx-sys = { path = "../nvngx-sys" }
+nvngx-sys = { version = "0.3.0",  path = "../nvngx-sys" }

--- a/crates/nvngx/Cargo.toml
+++ b/crates/nvngx/Cargo.toml
@@ -7,7 +7,7 @@ description = "NVIDIA NGX bindings."
 readme = "README.md"
 license = "MIT"
 keywords = ["nvidia", "ngx", "DLSS", "upscaling", "supersampling"]
-rust-version = "1.57"
+rust-version = "1.70"
 repository = "https://github.com/iddm/nvngx-rs"
 documentation = "https://docs.rs/nvngx-rs"
 


### PR DESCRIPTION
The submodule needs to be checked out whenever the crate is built, so that `bindgen` and `cc-rs` in the `build.rs` script of `nvngx-sys` can find their sources.
