### PR TITLE
nvngx-sys: Massively reduce size (and source of bugs/lints) of generated bindings

### DIFF
--- a/crates/nvngx-sys/build.rs
+++ b/crates/nvngx-sys/build.rs
@@ -111,6 +111,12 @@ fn main() {
         // Tell cargo to invalidate the built crate whenever any of the
         // included header files changed.
         .parse_callbacks(Box::new(bindgen::CargoCallbacks::new()))
+        // Types and functions defined by the SDK:
+        .allowlist_item("NVSDK_NGX_\\w+")
+        // Single exception for a function that doesn't adhere to the naming standard:
+        .allowlist_function("GetNGXResultAsString")
+        // Exportable symbols defined by our `bindings.c/h`, wrapping `static inline` helpers
+        .allowlist_function("HELPERS_NGX_\\w+")
         .impl_debug(true)
         .impl_partialeq(true)
         .prepend_enum_name(false)


### PR DESCRIPTION
Only the types and symbols (and their recursive transitive dependencies, which is the default) defined by the DLSS header that we reference need to be generated.  Not any other extraneous symbols defined in dependent (system) headers.

Omit these by setting up the necessary `allowlist`s on `bindgen`, so that only the DLSS SDK is generated and accessible.
