### PR TITLE
build: Compile helpers with `cc` crate instead of open-coded `clang`+`ar`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -47,6 +47,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f68f53c83ab957f72c32642f3868eec03eb974d1fb82e453128456482613d36"
 
 [[package]]
+name = "cc"
+version = "1.2.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3a42d84bb6b69d3a8b3eaacf0d88f179e1929695e1ad012b6cf64d9caaa5fd2"
+dependencies = [
+ "shlex",
+]
+
+[[package]]
 name = "cexpr"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -244,6 +253,7 @@ name = "nvngx-sys"
 version = "0.3.1"
 dependencies = [
  "bindgen",
+ "cc",
  "libc",
  "widestring",
 ]

--- a/crates/nvngx-sys/Cargo.toml
+++ b/crates/nvngx-sys/Cargo.toml
@@ -19,6 +19,7 @@ include = [
 
 [build-dependencies]
 bindgen = "0.72"
+cc = "1"
 
 [dependencies]
 widestring = "1"


### PR DESCRIPTION
To prepare for building on Windows, or with different compilers and setups in general, use the `cc` crate which is able to detect and configure a variety of compilers based on the host system as well as (cross-compilation!) compiler flags.

The `.compile()` call automatically sets up the `rustc-link-lib` flags for the linker to find and link against the generated `ngx_helpers` static object.
