### PR TITLE
Make include directory lowercase

### DIFF
--- a/crates/nvngx-sys/build.rs
+++ b/crates/nvngx-sys/build.rs
@@ -25,7 +25,14 @@ fn compile_helpers() {
     let mut build = cc::Build::new();
     build.file(SOURCE_FILE_PATH);
     if let Some(vulkan_sdk) = vulkan_sdk() {
-        build.include(vulkan_sdk.join("include"));
+        let vulkan_include = vulkan_sdk.join("include");
+        if !vulkan_include.exists() {
+            panic!(
+                "Vulkan SDK include path does not exist: {}",
+                vulkan_include.display()
+            )
+        }
+        build.include(vulkan_include);
     }
     build.compile("ngx_helpers");
 }

--- a/crates/nvngx-sys/build.rs
+++ b/crates/nvngx-sys/build.rs
@@ -25,7 +25,7 @@ fn compile_helpers() {
     let mut build = cc::Build::new();
     build.file(SOURCE_FILE_PATH);
     if let Some(vulkan_sdk) = vulkan_sdk() {
-        build.include(vulkan_sdk.join("Include"));
+        build.include(vulkan_sdk.join("include"));
     }
     build.compile("ngx_helpers");
 }


### PR DESCRIPTION
While including the library and building my project with it, I encountered the following compilation error:
```
cargo:warning=In file included from src/bindings.c:1:
cargo:warning=src/bindings.h:4:10: fatal error: vulkan/vulkan.h: No such file or directory
cargo:warning=    4 | #include <vulkan/vulkan.h>
cargo:warning=      |          ^~~~~~~~~~~~~~~~~
cargo:warning=compilation terminated.
```
Which by looking at the build.rs file, I assumed and confirmed it to be related to a typo in the include path of SDK's headers. This PR fixes it. I tested my code on Linux, not sure if on Windows the capitalisation is different. If so, we could handle that logic.

Another option would be to link the [Vulkan-Headers](https://github.com/KhronosGroup/Vulkan-Headers) as a submodule, but I think it may be overkill.