### PR TITLE
sys: Add architecture check and document the `cfg()` to use

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,21 @@ The DLSS version used by this crate: [`3.10.1.0`](https://github.com/NVIDIA/DLSS
 ## MSRV
 1.70
 
+## Platform support
+
+As of writing NVIDIA only distributes Linux (under `glibc`) and Windows libraries for the `x86_64` architecture.  Use the following `cfg()`-conditional to ensure that this crate and your code only compile under those conditions, and implement a fallback otherwise:
+
+```rust
+cfg(all(target_arch = "x86_64", any(target_os = "windows", target_os = "linux")))
+```
+
+Such as in a `Cargo.toml`:
+
+```toml
+[target.'cfg(all(target_arch = "x86_64", any(target_os = "windows", target_os = "linux")))'.dependencies]
+nvngx = "current.version"
+```
+
 ## DLSS integration example
 
 One can have something like that:

--- a/crates/nvngx-sys/build.rs
+++ b/crates/nvngx-sys/build.rs
@@ -40,12 +40,18 @@ fn compile_helpers() {
 fn main() {
     compile_helpers();
 
+    let target_arch = env::var("CARGO_CFG_TARGET_ARCH").unwrap();
+    assert_eq!(
+        target_arch, "x86_64",
+        "No libraries available for architecture `{target_arch}`"
+    );
+
     // Tell cargo to tell rustc to link to the libraries.
     let target_os = env::var("CARGO_CFG_TARGET_OS").unwrap();
     let dlss_library_path = Path::new(match target_os.as_str() {
         "windows" => "DLSS/lib/Windows_x86_64",
         "linux" => "DLSS/lib/Linux_x86_64",
-        x => todo!("No libraries for {x}"),
+        x => panic!("No libraries available for OS `{x}`"),
     });
 
     // Make the path relative to the crate source, where the DLSS submodule exists


### PR DESCRIPTION
NVIDIA only provides Linux and Windows libraries of DLSS, and only for the `x86_64` architecture.  We already error out if the `target_os` is something different (as this repository implements zero fallbacks and will likely fail linking) but didn't yet check the `target_arch`.

Secondly, document in the `README` how downstream crates should depend on `nvngx` with a `cfg()` such that it's not compiled on unsupported targets.

---

This all came up while we were using (an older version of) PR #38 in local CI: that PR actually disables the `todo!()`/`panic!()` such that linker errors are deferred to the final linking stage of a program (something that doesn't run under `cargo clippy` / `cargo check`...) for MacOS, and places the symbols in the dynamic table to be resolved at _runtime_, resulting in an error on app launch.  That is why I first and foremost want the build script to fail _as early as possible_, and secondly want to describe the `cfg()` that people should use to disable the `nvngx` crate dependency and their own code calling into it.  Thanks!
